### PR TITLE
Change unique_together index ordering for mysql

### DIFF
--- a/hvad/models.py
+++ b/hvad/models.py
@@ -168,7 +168,7 @@ class TranslatedFields(object):
             model._meta.original_attrs['unique_together'] = tuple(sconst)
         meta['unique_together'] = tuple(tconst)
         if not abstract:
-            meta['unique_together'] += (('language_code', 'master'),)
+            meta['unique_together'] += (('master', 'language_code'),)
 
         # Split fields in Meta.index_together
         sconst, tconst = self._split_together(


### PR DESCRIPTION
Multicolumn indexes in mysql only match the leftmost field. Before there was no index being used for "master_id". See http://dev.mysql.com/doc/refman/5.7/en/mysql-indexes.html
